### PR TITLE
Fix Devices readme

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -80,7 +80,7 @@ unzip r.zip
 rm r.zip
 
 # add main user to group that owns M8
-sudo usermod -G uucp deck
+sudo usermod -a -G uucp deck
 ```
 
 - in Desktop-mode, open steam, add non-steam game for `/home/deck/M8/rm8` and set working-dir to `/home/deck/M8`


### PR DESCRIPTION
Append the user to the given group instead of removing all other groups not listed (including wheel) which can result in using sudo rights.

From the man page of the `-G` flag of `usermod`:

> If the user is currently a member of a group which is not listed, the user will be removed from the group.